### PR TITLE
Issue 16

### DIFF
--- a/src/grassland_production/grassland_area.py
+++ b/src/grassland_production/grassland_area.py
@@ -10,30 +10,42 @@ class Areas:
         self.calibration_year = calibration_year
         self.default_calibration_year = default_calibration_year
 
-
     def get_proportion_weight(
-        self, area_nfs, farm_system_number, nfs_dict, calibration_year, system, grassland_type
+        self,
+        area_nfs,
+        farm_system_number,
+        nfs_dict,
+        calibration_year,
+        system,
+        grassland_type,
     ):
-        
         total = (
-                (nfs_dict["dairy"].loc[calibration_year,grassland_type].item() * farm_system_number.loc[calibration_year, "dairy"].item())
-                + (nfs_dict["beef"].loc[calibration_year,grassland_type].item() * farm_system_number.loc[calibration_year, "beef"].item())
-                + (nfs_dict["sheep"].loc[calibration_year,grassland_type].item()* farm_system_number.loc[calibration_year, "sheep"].item())
+            (
+                nfs_dict["dairy"].loc[calibration_year, grassland_type].item()
+                * farm_system_number.loc[calibration_year, "dairy"].item()
             )
-        
+            + (
+                nfs_dict["beef"].loc[calibration_year, grassland_type].item()
+                * farm_system_number.loc[calibration_year, "beef"].item()
+            )
+            + (
+                nfs_dict["sheep"].loc[calibration_year, grassland_type].item()
+                * farm_system_number.loc[calibration_year, "sheep"].item()
+            )
+        )
+
         system_area = area_nfs * farm_system_number.loc[calibration_year, system].item()
-        
-        result = system_area/total
+
+        result = system_area / total
 
         return result
-        
 
-    def get_total_nfs_areas_for_proportions(self, dairy_area_nfs, beef_area_nfs, sheep_area_nfs):
-
+    def get_total_nfs_areas_for_proportions(
+        self, dairy_area_nfs, beef_area_nfs, sheep_area_nfs
+    ):
         combined_dataframe = dairy_area_nfs + beef_area_nfs + sheep_area_nfs
 
         return combined_dataframe
-    
 
     def get_nfs_system_proportions(self):
         grassland_types = ["Grass silage", "Hay", "Pasture", "Rough grazing in use"]
@@ -42,13 +54,13 @@ class Areas:
         beef_area_nfs = self.loader_class.beef_area_nfs()
         sheep_area_nfs = self.loader_class.sheep_area_nfs()
 
-        nfs_dict= {
+        nfs_dict = {
             "dairy": dairy_area_nfs,
             "beef": dairy_area_nfs,
             "sheep": dairy_area_nfs,
         }
 
-        #total_areas_nfs = self.get_total_nfs_areas_for_proportions(dairy_area_nfs, beef_area_nfs, sheep_area_nfs)
+        # total_areas_nfs = self.get_total_nfs_areas_for_proportions(dairy_area_nfs, beef_area_nfs, sheep_area_nfs)
 
         farm_system_number = self.loader_class.nfs_farm_numbers()
 
@@ -62,8 +74,6 @@ class Areas:
             0, columns=dairy_area_nfs.columns, index=dairy_area_nfs.index
         )
 
-
-
         systems_dict = {
             "dairy": dairy_nfs_system_proportions,
             "beef": beef_nfs_system_proportions,
@@ -74,10 +84,14 @@ class Areas:
         for sys, grassland_type, ix in product(
             systems_dict.keys(), grassland_types, dairy_nfs_system_proportions.index
         ):
-            
             try:
                 systems_dict[sys].at[ix, grassland_type] = self.get_proportion_weight(
-                    nfs_dict[sys].loc[ix, grassland_type], farm_system_number, nfs_dict, ix, sys, grassland_type
+                    nfs_dict[sys].loc[ix, grassland_type],
+                    farm_system_number,
+                    nfs_dict,
+                    ix,
+                    sys,
+                    grassland_type,
                 )
             except KeyError:
                 if default_year_flag == True:
@@ -92,11 +106,10 @@ class Areas:
                     nfs_dict,
                     self.default_calibration_year,
                     sys,
-                    grassland_type
+                    grassland_type,
                 )
 
         return systems_dict["dairy"], systems_dict["beef"], systems_dict["sheep"]
-    
 
     def get_nfs_within_system_grassland_distribution(self):
         dairy_area_nfs = self.loader_class.dairy_area_nfs()


### PR DESCRIPTION
# Description
closes #16 

The system proportions function in the grassland_area file has been fixed. 

I have adjusted the method get_proportion_weight() to take a dictionary of nfs areas for each system. 

I have also run some tests, the total area from the tests outputs as: 3948578.85 ha 

I have also tested the proportions and the areas indivually, printing them to the terminal and validating their output in excel. 

Seems to be working, some of the values look simlar across the grassland types, but this seems to be correct. 


Fixes # 16

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests using the test suite, and with excel to validate individual values 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

